### PR TITLE
Add March 2021 agenda document

### DIFF
--- a/meetings/2021-03-24.md
+++ b/meetings/2021-03-24.md
@@ -1,0 +1,39 @@
+# TSC Meeting: February 27, 2021
+
+## Meeting information
+
+**February 27, 2021 11a EST**
+
+* Zoom: [https://zoom.us/j/96738269957](https://zoom.us/j/96738269957) (password: `chipstsc`)
+* Recording: 
+* How to join: Please join the Zoom call and edit your username to include your affiliation (e.g., the project you represent or the company you work for).
+
+*Please note that our Zoom calls are recorded/livestreamed so that we can post them to our [YouTube channel](https://youtube.chipsalliance.org).*
+
+## Attendees
+
+* Henry Cook, TSC chair
+* Michael Gielda
+* Rob Mains
+* Brian Warner
+
+## Agenda
+
+Please add agenda items by opening a PR prior to the meeting.
+
+1. Welcome
+1. Review Applications for sandbox
+  - Rocket Chip: https://github.com/chipsalliance/tsc/pull/19
+  - Chisel: https://github.com/chipsalliance/tsc/pull/18
+
+## Minutes
+
+Minutes captured by: [Brian Warner](https://github.com/brianwarner)
+
+### Welcome
+
+[...] opened the meeting at 11:[..] am ET.
+
+### Adjournment
+
+[...] closed the meeting at 11:[..] am ET.

--- a/meetings/2021-03-24.md
+++ b/meetings/2021-03-24.md
@@ -1,8 +1,8 @@
-# TSC Meeting: February 27, 2021
+# TSC Meeting: March 24, 2021
 
 ## Meeting information
 
-**February 27, 2021 11a EST**
+**March 24, 2021 11a EST**
 
 * Zoom: [https://zoom.us/j/96738269957](https://zoom.us/j/96738269957) (password: `chipstsc`)
 * Recording: 
@@ -22,13 +22,11 @@
 Please add agenda items by opening a PR prior to the meeting.
 
 1. Welcome
-1. Review Applications for sandbox
-  - Rocket Chip: https://github.com/chipsalliance/tsc/pull/19
-  - Chisel: https://github.com/chipsalliance/tsc/pull/18
-
+1. Review applications for sandbox
+1. Review applications for graduated
 ## Minutes
 
-Minutes captured by: [Brian Warner](https://github.com/brianwarner)
+Minutes captured by: [...]
 
 ### Welcome
 


### PR DESCRIPTION
This is a trivial PR adding a blank meeting template for March. I'll merge it directly.

Signed-off-by: Brian Warner <brian@bdwarner.com>