### PR TITLE
Update projects list and enable TSC to create workgroups

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,13 @@ The CHIPS Alliance TSC is governed by a [Technical Charter](https://technical-ch
 
 In addition, as provided under the Technical Charter, CHIPS Alliance has adopted a [Code of Conduct](https://lfprojects.org/policies/code-of-conduct/) that applies to all CHIPS Alliance activities and spaces.
 
+## CHIPS Alliance Projects
+
+#### Sandbox projects
+
+* [Chisel (incl. Firrtl and treadl)](https://github.com/chipsalliance/tsc/blob/HEAD/projects/sandbox/chisel_and_related_projects.md)
+* [Rocket Chip](https://github.com/chipsalliance/tsc/blob/HEAD/projects/sandbox/rocket_chip.md)
+
 ## Getting Oriented
 
 This repo documents the day-to-day policies and procedures of the CHIPS Alliance TSC. It provides a framework for self-governance, and addresses topics too granular for the [Technical Charter](https://technical-charter.chipsalliance.org).
@@ -81,7 +88,7 @@ Each project is categorized according to a [project lifecycle process](./project
 
 #### Workgroup levels
 
-* **Active**: Contains at least one Graduated project.
+* **Active**: Contains at least one Graduated project, or a majority of the TSC has voted to create the workgroup to collaborate on future projects.
 * **Archived**: No longer contains any Graduated projects.
 
 The TSC has sole authority over a project's lifecycle stage and workgroup, including the decision to accept or reject project proposals. It also may create or consolidate workgroups at its discretion.
@@ -101,21 +108,15 @@ All projects will go through the onboarding process. At a high level, this inclu
 
 Linux Foundation staff are able to help with this process.
 
-<!--### List of projects by workgroup
+### Resources
 
-#### Workgroup A
+All Graduated projects and Active workgroups can make use of the CHIPS Alliance collaboration resourcs, including:
 
-* [Project 1](LINK-TO-PROJECT-1) (Graduated)
-* [Project 2](LINK-TO-PROJECT-2) (Graduated)
-
-#### Workgroup B
-
-* [Project 3](LINK-TO-PROJECT-3) (Graduated)
-* [Project 4](LINK-TO-PROJECT-4) (Sandbox)
-
-#### Archived projects
-
-* [Project 6](LINK-TO-PROJECT-6)-->
+* Access to the shared Zoom account
+* Meetings listed on the public [CHIPS Alliance calendar](https://calendar.chipsalliance.org)
+* Mailing lists on [lists.chipsalliance.org](https://lists.chipsalliance.org)
+* Credential storage and sharing through LastPass
+* GitHub repos and teams in the [`chipsalliance` GitHub org](https://github.com/chipsalliance)
 
 ### The CHIPS Alliance Commons: Related projects and initiatives
 

--- a/projects/README.md
+++ b/projects/README.md
@@ -13,7 +13,7 @@ There are three project categories:
 
 ## Sandbox
 
-*Sandbox projects* are projects which plan to join the CHIPS Alliance, but have not yet met the prerequisites to formally join. Projects may optionally make use of the Sandbox stage in order to request TSC time and attention in preparing for their application to become a part of CHIPS Alliance.
+*[Sandbox projects](https://github.com/chipsalliance/tsc/blob/HEAD/projects/sandbox)* are projects which plan to join the CHIPS Alliance, but have not yet met the prerequisites to formally join. Projects may optionally make use of the Sandbox stage in order to request TSC time and attention in preparing for their application to become a part of CHIPS Alliance.
 
 The Sandbox stage is optional, and Sandbox projects are not yet considered part of CHIPS Alliance.
 
@@ -39,7 +39,7 @@ When a Sandbox proposal is accepted, the PR may be landed.
 
 ## Graduated
 
-*Graduated projects* are projects which have applied and been formally accepted as CHIPS Alliance projects by the TSC. Graduated projects are assigned to a Workgroup, and are officially a part of CHIPS Alliance.
+*[Graduated projects](https://github.com/chipsalliance/tsc/blob/HEAD/projects/graduated)* are projects which have applied and been formally accepted as CHIPS Alliance projects by the TSC. Graduated projects are assigned to a Workgroup, and are officially a part of CHIPS Alliance.
 
 However, achieving Graduated status requires more than maturity and adoption. The TSC is run by and for the technical community, and it can only function with involvement from project leaders. Representatives from Graduated projects are expected to take an active role in TSC and CHIPS Alliance processes. For example, participating in TSC meetings, volunteering as a program committee member for events, participating in mentoring initiatives, and helping Sandbox projects prepare for their Graduated status application.
 
@@ -81,7 +81,7 @@ When a Graduated proposal is accepted, the PR may be landed.
 
 ## Archived
 
-*Archived projects* are projects which no longer have sufficient momentum to justify an active state in CHIPS Alliance. By archiving a project, CHIPS Alliance is indicating that downstream users should not expect any updates, including security fixes or backports.
+*[Archived projects](https://github.com/chipsalliance/tsc/blob/HEAD/projects/archived)* are projects which no longer have sufficient momentum to justify an active state in CHIPS Alliance. By archiving a project, CHIPS Alliance is indicating that downstream users should not expect any updates, including security fixes or backports.
 
 The decision to move a project to Archived is not taken lightly by the TSC, and each situation will be unique.  However, reasons which could lead to an Archived state may include:
 

--- a/projects/sandbox/README.md
+++ b/projects/sandbox/README.md
@@ -4,4 +4,5 @@ CHIPS Alliance uses a [project lifecycle process](/README.md#lifecycle) to categ
 
 Current Sandbox projects:
 
-* None
+* [Chisel (incl. Firrtl and treadl)](https://github.com/chipsalliance/tsc/blob/HEAD/projects/sandbox/chisel_and_related_projects.md)
+* [Rocket Chip](https://github.com/chipsalliance/tsc/blob/HEAD/projects/sandbox/rocket_chip.md)


### PR DESCRIPTION
Per our discussion last week, some updates to the readme that enable the TSC to create anticipatory workgroups by majority vote instead of waiting for a graduated project.

Also, this adds links to the Sandbox projects.

Finally, this enumerates some of the collaboration tools that projects can expect when they join.

Signed-off-by: Brian Warner <brian@bdwarner.com>