### PR TITLE
Add initial analog working group info

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ In addition, as provided under the Technical Charter, CHIPS Alliance has adopted
 * [Chisel (incl. Firrtl and treadle)](https://github.com/chipsalliance/tsc/blob/HEAD/projects/sandbox/chisel_and_related_projects.md)
 * [Rocket Chip](https://github.com/chipsalliance/tsc/blob/HEAD/projects/sandbox/rocket_chip.md)
 
+#### Working Groups
+
+* [Analog](https://github.com/chipsalliance/tsc/blob/HEAD/working_groups/analog/README.md)
+
 ## Getting Oriented
 
 This repo documents the day-to-day policies and procedures of the CHIPS Alliance TSC. It provides a framework for self-governance, and addresses topics too granular for the [Technical Charter](https://technical-charter.chipsalliance.org).

--- a/working_groups/analog/README.md
+++ b/working_groups/analog/README.md
@@ -4,6 +4,12 @@ The Analog working group was formed by the CHIPS Alliance TSC to explore collabo
 
 ## Mission
 
+The mission of the Analog WG will be to:
+
+* identify open source IP in the Analog/Mixed-Signal domain and help it flourish
+* share and co-develop new, open source based design methodologies in the Analog/Mixed-Signal space (such as generators and generator frameworks)
+* discuss and share experiences related to Analog/Mixed-Signal design to identify gaps in the existing ecosytstem and potential improvements
+* identify neigboring areas where open source Analog/Mixed-Signal design methodologies and IP could result in radical improvements (e.g. chiplets, memory designs etc.)
 
 ## Collaboration
 

--- a/working_groups/analog/README.md
+++ b/working_groups/analog/README.md
@@ -1,0 +1,17 @@
+# Analog Working Group
+
+The Analog working group was formed by the CHIPS Alliance TSC to explore collaborations in Analog design and verification.
+
+## Mission
+
+
+## Collaboration
+
+### Mailing list
+
+Anyone is allowed to join and participate on [the `analog-wg` mailing list](https://lists.chipsalliance.org/g/analog-wg/).
+
+### Calendar
+
+Meetings and events will be posted on the main [CHIPS Alliance calendar](https://calendar.chipsalliance.org).
+


### PR DESCRIPTION
Initial documents for the analog working group. @mgielda and @hcook, I left the mission blank, assuming that you might be better at drafting a 2-3 sentence summary.

The mailing list is set up, I'll add both of you to it.

Signed-off-by: Brian Warner <brian@bdwarner.com>