### PR TITLE
Add SV tests into Graduated

### DIFF
--- a/projects/sandbox/sv-tests.md
+++ b/projects/sandbox/sv-tests.md
@@ -14,7 +14,25 @@
 * Who uses this project, and at what scale: Google, Antmicro, WDC, numerous users in open source community
 * Why does the project want to join CHIPS Alliance: To help drive SystemVerilog support in open source ASIC/FPGA tooling
 * Primary contact from the project during the Sandbox application process:
- * Name: Tom Gorochowik
- * Email: tgorochowik@antmicro.com
- * GitHub handle: @tgorochowik
- * Role within the project: Maintainer
+  * Name: Tom Gorochowik
+  * Email: tgorochowik@antmicro.com
+  * GitHub handle: @tgorochowik
+  * Role within the project: Maintainer
+
+### Graduation application
+
+* Total number of active committers: https://github.com/SymbiFlow/sv-tests/graphs/contributors
+* Brief description of release methodology and mechanics: No regular release policy has been adopted as of yet; a policy is going to be developed in collaboration within CHIPS.
+* Link to draft mission statement: https://github.com/SymbiFlow/sv-tests/blob/master/README.md
+* Link to logo in .svg format: None
+* Confirmation that the project adopts the [CHIPS Alliance Code of Conduct](https://lfprojects.org/policies/code-of-conduct/) upon acceptance: Confirmed
+* Confirmation that the project will adopt the [CHIPS Alliance IP policy](https://technical-charter.chipsalliance.org) upon acceptance: Confirmed
+* Confirmation that the project will add CHIPS Alliance header or footer text and links to its websites upon acceptance: Confirmed
+* Confirmation that the project will transfer any registered trademarks and domain names to the Linux Foundation upon acceptance: N/A
+* Link to documented process for reporting security vulnerabilities: The project will use [CHIPS Alliance's default security policy](https://github.com/chipsalliance/tsc#reporting-security-vulnerabilities)
+* **For specifications** Confirmation there is at least one public reference implementation: N/A
+* Primary contact from the project during the Graduation application process:
+  * Name: Tom Gorochowik
+  * Email: tgorochowik@antmicro.com
+  * GitHub handle: @tgorochowik
+  * Role within the project: Maintainer

--- a/projects/sandbox/sv-tests.md
+++ b/projects/sandbox/sv-tests.md
@@ -1,0 +1,20 @@
+# Project application: SV tests
+
+## Application
+
+### Sandbox application
+
+* Project name: SV tests
+* Project repo(s): https://github.com/SymbiFlow/sv-tests
+* Brief summary of the project: SystemVerilog test framework for checking SV spec support coverage in various open source tools - parsers, linters, formatters etc.
+* Project's open source license: ISC
+* Link to issue tracker: https://github.com/SymbiFlow/sv-tests/issues
+* Link to website: https://symbiflow.github.io/sv-tests-results/
+* Links to social media accounts: N/A
+* Who uses this project, and at what scale: Google, Antmicro, WDC, numerous users in open source community
+* Why does the project want to join CHIPS Alliance: To help drive SystemVerilog support in open source ASIC/FPGA tooling
+* Primary contact from the project during the Sandbox application process:
+ * Name: Tom Gorochowik
+ * Email: tgorochowik@antmicro.com
+ * GitHub handle: @tgorochowik
+ * Role within the project: Maintainer


### PR DESCRIPTION
This adds SV tests into sandbox for now. As soon as we complete the due diligence, we can move it over to graduated.