### PR TITLE
Add Diplomacy to Sandbox projects

### DIFF
--- a/projects/sandbox/diplomacy.md
+++ b/projects/sandbox/diplomacy.md
@@ -1,0 +1,40 @@
+# Project application: Diplomacy SoC Framework
+
+## Application
+
+### Sandbox application
+
+* Project name: Diplomacy SoC Framework
+* Project repo(s): https://github.com/chipsalliance/diplomacy/
+* Brief summary of the project: a SoC framework based on Chisel.
+* Project's open source license: Apache 2.0
+* Link to issue tracker: https://github.com/chipsalliance/diplomacy/issues
+* Link to website: N/A
+* Links to social media accounts: N/A
+* Who uses this project, and at what scale: RocketChip, FireSim, Boom, XiangShan, and other Chisel projects which depends on a configurable SoC.
+* Why does the project want to join CHIPS Alliance: This project used to belong to RocketChip, however since RocketChip is too large to maintain a stable API, I'm considering to split diplomacy out of RocketChip and to publish it to maven. Different interconnect protocols(TileLink, AXI/ACE, Wishbone) can depend on Diplomacy to provide a general interconnect API to users.
+* Primary contact from the project during the Sandbox application process:
+  * Name: Jiuyang Liu
+  * Email: liu@jiuyang.me
+  * GitHub handle: sequencer
+  * Role within the project: Maintainer
+
+*Projects applying for Sandbox status may stop here.*
+
+### Graduation application
+
+* Total number of active committers:
+* Brief description of release methodology and mechanics:
+* Link to draft mission statement:
+* Link to logo in .svg format
+* Confirmation that the project adopts the [CHIPS Alliance Code of Conduct](https://lfprojects.org/policies/code-of-conduct/) upon acceptance:
+* Confirmation that the project will adopt the [CHIPS Alliance IP policy](https://technical-charter.chipsalliance.org) upon acceptance:
+* Confirmation that the project will add CHIPS Alliance header or footer text and links to its websites upon acceptance:
+* Confirmation that the project will transfer any registered trademarks and domain names to the Linux Foundation upon acceptance:
+* Link to documented process for reporting security vulnerabilities:
+* **For specifications** Confirmation there is at least one public reference implementation:
+* Primary contact from the project during the Graduation process:
+  * Name:
+  * Email:
+  * GitHub handle:
+  * Role within the project:


### PR DESCRIPTION
Diplomacy was created by @hcook and @terpstra as the SoC infrastructure of Rocket-Chip.
I used to be a contributor to diplomacy, wrote a full diplomacy(LazyModule, Nodes) documentations, and some improvements on codebase.
I'm proposing a minimal standalone diplomacy framework for stable API for better versioning, thus different interconnect protocols can be implemented with diplomacy.
After hosting this in chipsalliance, I'm going to:

0. edit documentations and adding unit tests to diplomacy APIs.
1. publish it to maven.
2. make RocketChip depends on this.
3. implement a pure ACE/TileLink/Wishbone with this library.