### PR TITLE
Normalize WG naming ("workgroups" not "working groups")

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,14 +31,14 @@ In addition to Graduated projects which delegate one member each to the TSC (see
 
 See [Sandbox projects](./projects/sandbox) for a list of projects currently in Sandbox.
 
-## Working Groups list
+## Workgroups list
 
-Projects are organized into Working Groups for the purpose of e.g. organizing meetings which aggregate related projects and topical areas.
+Projects are organized into Workgroups for the purpose of e.g. organizing meetings which aggregate related projects and topical areas.
 
-Currently, the following working groups have been established:
+Currently, the following workgroups have been established:
 
-* [Analog](https://github.com/chipsalliance/tsc/blob/HEAD/working_groups/analog/README.md)
-* [Tools](https://github.com/chipsalliance/tsc/blob/HEAD/working_groups/tools/README.md)
+* [Analog](https://github.com/chipsalliance/tsc/blob/HEAD/workgroups/analog/README.md)
+* [Tools](https://github.com/chipsalliance/tsc/blob/HEAD/workgroups/tools/README.md)
 * Chisel
 * Rocket
 * Interconnects

--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ Projects are organized into Workgroups for the purpose of e.g. organizing meetin
 
 Currently, the following workgroups have been established:
 
-* [Analog](https://github.com/chipsalliance/tsc/blob/HEAD/workgroups/analog/README.md)
-* [Tools](https://github.com/chipsalliance/tsc/blob/HEAD/workgroups/tools/README.md)
+* [Analog](./workgroups/analog/README.md)
+* [Tools](./workgroups/tools/README.md)
 * Chisel
 * Rocket
 * Interconnects

--- a/meetings/2021-02-24.md
+++ b/meetings/2021-02-24.md
@@ -85,19 +85,19 @@ Brian gave a brief update on the CLA, and noted that the system is up and runnin
 
 Michael next discussed the CHIPS Alliance Commons, and noted that they can be used for projects that haven't yet joined but plan to.
 
-Michael also asked whether working groups can be set up that anticipate future CHIPS Alliance communities. He noted discussions with Silicon Austria and Infineon, and that it would be helpful to have an understanding that we can set up a working group around analog design, for example. He noted there is definite interest in creating a space where people can collaborate around BAG, and that it would be helpful for the CHIPS Alliance to express interest and willingness to host the conversations.
+Michael also asked whether workgroups can be set up that anticipate future CHIPS Alliance communities. He noted discussions with Silicon Austria and Infineon, and that it would be helpful to have an understanding that we can set up a workgroup around analog design, for example. He noted there is definite interest in creating a space where people can collaborate around BAG, and that it would be helpful for the CHIPS Alliance to express interest and willingness to host the conversations.
 
-Rob noted that analog is the long pole, and that there are multiple universities interested in a place to have the discussions. He noted it makes sense to formulate a working group. Henry agreed.
+Rob noted that analog is the long pole, and that there are multiple universities interested in a place to have the discussions. He noted it makes sense to formulate a workgroup. Henry agreed.
 
-**Action:** Brian to add instructions on what tools are available to working groups (Zoom, calendar, mailing list, etc.) and how to ask for them.
+**Action:** Brian to add instructions on what tools are available to workgroups (Zoom, calendar, mailing list, etc.) and how to ask for them.
 
-Michael noted that this will help provide a connection between communities, and this will also help clarify the value of joining CHIPS Alliance as a member. Michael asked how to set up a working group. Brian noted that currently, working groups are defined as containing at least one Graduated project. He noted that this definition can be changed, and to do what makes the most sense. Michael expressed support for being able to set up a working group in advance.
+Michael noted that this will help provide a connection between communities, and this will also help clarify the value of joining CHIPS Alliance as a member. Michael asked how to set up a workgroup. Brian noted that currently, workgroups are defined as containing at least one Graduated project. He noted that this definition can be changed, and to do what makes the most sense. Michael expressed support for being able to set up a workgroup in advance.
 
 Henry asked if the definition should be "Actively meeting," instead of containing a Graduated project.
 
 **Action:** Michael to suggest alternate language.
 
-Michael noted that analog will probably be the first working group to be created this way.
+Michael noted that analog will probably be the first workgroup to be created this way.
 
 Brian asked if we should have a project go through the CHIPS Alliance Commons onboarding process, noting that it just takes a vote. Michael agreed it would make sense to do this before the next meeting with BAG. Brian noted that it would be helpful to go through this process so that we understand that it works. The main thing here would be to make sure that we have the messaging right.
 

--- a/projects/graduated/OpenFASOC.md
+++ b/projects/graduated/OpenFASOC.md
@@ -14,7 +14,7 @@
 * Link to website: https://fasoc.engin.umich.edu/
 * Links to social media accounts:
 * Who uses this project, and at what scale: This project has been used by UMich (MICL) for many tapeouts as well as education and research. This projects has also been used to enable users who are part of the open source community (skywater 130nm, efabless).
-* Why does the project want to join CHIPS Alliance: In order to actively contribute and help the analog working group (Organization, workshops, support and guidance, etc..) as well as preaching for a fully open source automated AMS design generation
+* Why does the project want to join CHIPS Alliance: In order to actively contribute and help the analog workgroup (Organization, workshops, support and guidance, etc..) as well as preaching for a fully open source automated AMS design generation
 * Primary contact from the project during the Sandbox application process:
   * Name: Mehdi Saligane
   * Email: mehdi@umich.edu

--- a/workgroups/analog/README.md
+++ b/workgroups/analog/README.md
@@ -1,6 +1,6 @@
-# Analog Working Group
+# Analog Workgroup
 
-The Analog working group was formed by the CHIPS Alliance TSC to explore collaborations in open source Analog/Mixed-Signal design and verification.
+The Analog workgroup was formed by the CHIPS Alliance TSC to explore collaborations in open source Analog/Mixed-Signal design and verification.
 
 ## Mission
 

--- a/workgroups/tools/README.md
+++ b/workgroups/tools/README.md
@@ -1,6 +1,6 @@
-# Tools Working Group
+# Tools Workgroup
 
-The Tools working group (WG) of CHIPS Alliance covers a wide array of open source tooling for ASIC and FPGA design, mostly focusing around digital design (as there is a separate Analog WG that focuses on AMS design flows). 
+The Tools workgroup (WG) of CHIPS Alliance covers a wide array of open source tooling for ASIC and FPGA design, mostly focusing around digital design (as there is a separate Analog WG that focuses on AMS design flows).
 
 ## Mission
 


### PR DESCRIPTION
Signed-off-by: Michael Gielda <mgielda@antmicro.com>