### PR TITLE
Add CLA status for 2023-01-12

### DIFF
--- a/cla/CLA-status.yml
+++ b/cla/CLA-status.yml
@@ -1,0 +1,10 @@
+CLA:
+- Antmicro
+- Google
+- SiFive
+- Western Digital
+- Nvidia
+OWFa:
+- Google
+- SiFive
+- Western Digital


### PR DESCRIPTION
This is to reflect/track the current corporate CLA status (including OWFa).