### PR TITLE
Revert "Update caliptra.md"

### DIFF
--- a/workgroups/caliptra.md
+++ b/workgroups/caliptra.md
@@ -1,3 +1,8 @@
-| Title | Leader | Website | Mailing List | Meeting date/time | Meeting Link |
-|:------|:-------|:--------|:-------------|:------------------|:-------------|
-|Caliptra Workgroup|Bharat Pillilli|https://github.com/chipsalliance/Caliptra|https://lists.chipsalliance.org/g/caliptra-wg|Every Friday 9am PST|[Microsoft Teams Meeting Link](https://www.google.com/url?q=https://teams.microsoft.com/l/meetup-join/19%253ameeting_ZTViMGQ5MDYtNGY4MS00ODY5LTg4NmQtNDE3N2QwZmVhMmNh%2540thread.v2/0?context%3D%257b%2522Tid%2522%253a%252272f988bf-86f1-41af-91ab-2d7cd011db47%2522%252c%2522Oid%2522%253a%2522661ec88e-77cb-431c-935a-b377b1078af4%2522%257d&sa=D&source=calendar&ust=1677708216834194&usg=AOvVaw2Q-Sfw1s3hg4PpPNKjveV6)|
+---
+title: Caliptra Workgroup
+leader: Bharat Pillilli
+website: https://github.com/chipsalliance/Caliptra
+mailing_list: https://lists.chipsalliance.org/g/caliptra-wg
+meeting_dates: Every Friday 9am PST 
+---
+[Microsoft Teams Meeting Link](https://www.google.com/url?q=https://teams.microsoft.com/l/meetup-join/19%253ameeting_ZTViMGQ5MDYtNGY4MS00ODY5LTg4NmQtNDE3N2QwZmVhMmNh%2540thread.v2/0?context%3D%257b%2522Tid%2522%253a%252272f988bf-86f1-41af-91ab-2d7cd011db47%2522%252c%2522Oid%2522%253a%2522661ec88e-77cb-431c-935a-b377b1078af4%2522%257d&sa=D&source=calendar&ust=1677708216834194&usg=AOvVaw2Q-Sfw1s3hg4PpPNKjveV6)


### PR DESCRIPTION
Reverts chipsalliance/tsc#108

It looks like the new website assumes a Markdown Table format - reverting this change to keep the older format