### PR TITLE
Add more explicit yml errors to the project checker

### DIFF
--- a/.github/check_projects_syntax.py
+++ b/.github/check_projects_syntax.py
@@ -32,7 +32,7 @@ for filename in sys.argv[1:]:
         with open(filename) as f:
             data = yaml.safe_load(f)
     except Exception as e:
-        fail(f"Unable to parse {filename} as yml")
+        fail(f"Unable to parse {filename} as yml: {e}")
 
     # it needs to match fields from sandbox
     if "status" not in data:


### PR DESCRIPTION
`Unable to parse XXX as yml`  was not very informative. This can be seen for example in #136 

With this change, the error would be:
```
Unable to parse projects/chisel.yml as yml: mapping values are not allowed here
  in "projects/chisel.yml", line 47, column 81
```

It directly points to the colon character that causes the issue.